### PR TITLE
Create Question 2 (Nachoes)

### DIFF
--- a/Question 2 (Nachoes)
+++ b/Question 2 (Nachoes)
@@ -1,0 +1,40 @@
+public static void finish() {
+    Lib.debug(dbgThread, "Finishing thread: " + currentThread.toString());
+    
+    Machine.interrupt().disable(); // Disable interrupts for atomicity
+    Machine.autoGrader().finishingCurrentThread();
+    
+    Lib.assertTrue(toBeDestroyed == null); 
+    toBeDestroyed = currentThread; // Mark the current thread to be destroyed
+    
+    currentThread.status = statusFinished;
+    
+    // Wake up any thread waiting on join()
+    if (currentThread.joiningThread != null) {
+        currentThread.joiningThread.ready();
+        currentThread.joiningThread = null;
+    }
+    
+    sleep(); // Switch context to another thread
+}
+^(lines 194-207) 
+
+public void join() {
+    Lib.debug(dbgThread, "Joining to thread: " + toString());
+    
+    Lib.assertTrue(this != currentThread); // Cannot join itself
+
+    boolean intStatus = Machine.interrupt().disable(); // Disable interrupts for atomicity
+    
+    if (joiningThread != null) {
+        Lib.assertTrue(false, "join() called more than once on the same thread!");
+    }
+    
+    if (this.status != statusFinished) {
+        joiningThread = currentThread; // Store the joining thread
+        currentThread.sleep(); // Put the calling thread to sleep
+    }
+    
+    Machine.interrupt().restore(intStatus); // Restore interrupts
+}
+^(lines 283-288)


### PR DESCRIPTION
This might be the completed "In KThread.java: implement line 283: join() and line 194: finish() "

(10%) Implement KThread.join(), which synchronizes the calling thread with the completion of
the called thread. As an example, if thread B executes the following:
KThread A = new KThread(...);
...
A.join();
We say that thread B joins with thread A. When B calls join on A, there are two possibilities. If A has
already finished, then B returns immediately from join without waiting. If A has not finished, then B
waits inside of join until A finishes; when A finishes, it resumes B. Often thread B is called the “parent”
and A is called the “child” since a common pattern is for a thread that creates child threads to join on
them to wait for them to finish. However, note that any thread can call KThread.join() on another (it
does not have to be a parent/child relationship)
Note that: (a) join does not have to be called on a thread. A thread should be able to finish successfully
even if no other thread calls join on it; (b) A thread cannot join to itself. (The initial implementation
already checks for this case and invokes Lib.assert() when it happens. Keep this Lib.assert() call
in your code); (c) Join can be called on a thread at most once. If thread B calls join on A, then it is an
error for B or any other thread C to call join on A again. Assert on this error; (d) A thread must finish
executing normally whether or not it is joined.


public static void finish() {
    Lib.debug(dbgThread, "Finishing thread: " + currentThread.toString());
    
    Machine.interrupt().disable(); // Disable interrupts for atomicity
    Machine.autoGrader().finishingCurrentThread();
    
    Lib.assertTrue(toBeDestroyed == null); 
    toBeDestroyed = currentThread; // Mark the current thread to be destroyed
    
    currentThread.status = statusFinished;
    
    // Wake up any thread waiting on join()
    if (currentThread.joiningThread != null) {
        currentThread.joiningThread.ready();
        currentThread.joiningThread = null;
    }
    
    sleep(); // Switch context to another thread
}
^(lines 194-207)

public void join() {
    Lib.debug(dbgThread, "Joining to thread: " + toString());
    
    Lib.assertTrue(this != currentThread); // Cannot join itself

    boolean intStatus = Machine.interrupt().disable(); // Disable interrupts for atomicity
    
    if (joiningThread != null) {
        Lib.assertTrue(false, "join() called more than once on the same thread!");
    }
    
    if (this.status != statusFinished) {
        joiningThread = currentThread; // Store the joining thread
        currentThread.sleep(); // Put the calling thread to sleep
    }
    
    Machine.interrupt().restore(intStatus); // Restore interrupts
}
^(lines 283-288)